### PR TITLE
Add --date-format option, Pass com_author

### DIFF
--- a/nagios_commander.sh
+++ b/nagios_commander.sh
@@ -328,6 +328,7 @@ curl -sS $DATA $NAGIOS_INSTANCE/cmd.cgi -u "$USERNAME:$PASSWORD" \
     --data cmd_typ=$CMD_TYP \
     --data cmd_mod=2 \
     --data "com_data=$COMMENT" \
+    --data "com_author=$USERNAME" \
     --data "start_time=$NOW" \
     --data "end_time=$NOW_ADD_MINS" \
     --data fixed=1 \


### PR DESCRIPTION
Cherry picked changes from [@davemarchevsky](https://github.com/davemarchevsky/nagios_commander/commit/715b208a8c787d5f0df208a8058f665bb46f86df) fork:
- 3b8601158c10b8fd89ececde57219f56668394f0: Pass com_author when scheduling downtime
- 10b6b1cb3d53d1fb3ddaae22b2b7fe7990958d0d: Add --date-format option + refactor date format strings to respect new option

cc @davemarchevsky